### PR TITLE
Serve graphs in media

### DIFF
--- a/kitchen/dashboard/graphs.py
+++ b/kitchen/dashboard/graphs.py
@@ -7,7 +7,7 @@ import threading
 import pydot
 from logbook import Logger
 
-from kitchen.settings import STATIC_ROOT, REPO, COLORS
+from kitchen.settings import MEDIA_ROOT, REPO, COLORS
 from kitchen.dashboard.chef import get_role_groups
 
 log = Logger(__name__)
@@ -132,7 +132,7 @@ def generate_node_map(nodes, roles, show_hostnames=True):
             graph.add_edge(edge)
 
     # Generate graph
-    filename = os.path.join(STATIC_ROOT, 'img', 'node_map.svg')
+    filename = os.path.join(MEDIA_ROOT, 'node_map.svg')
     timeout = 10.0  # Seconds
     graph_thread = GraphThread(filename, graph)
     graph_thread.start()

--- a/kitchen/dashboard/tests.py
+++ b/kitchen/dashboard/tests.py
@@ -103,19 +103,23 @@ class TestData(TestCase):
 
     def test_filter_nodes_roles(self):
         """Should filter nodes acording to their virt value"""
-        data = chef.filter_nodes(chef.get_nodes_extended(), roles='dbserver')
+        data = chef.filter_nodes(chef.get_nodes_extended(),
+                                 roles='dbserver')
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0]['name'], "testnode3.mydomain.com")
 
-        data = chef.filter_nodes(chef.get_nodes_extended(), roles='loadbalancer')
+        data = chef.filter_nodes(chef.get_nodes_extended(),
+                                 roles='loadbalancer')
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['name'], "testnode1")
 
-        data = chef.filter_nodes(chef.get_nodes_extended(), roles='webserver')
+        data = chef.filter_nodes(chef.get_nodes_extended(),
+                                 roles='webserver')
         self.assertEqual(len(data), 4)
         self.assertEqual(data[0]['name'], "testnode2")
 
-        data = chef.filter_nodes(chef.get_nodes_extended(), roles='webserver,dbserver')
+        data = chef.filter_nodes(chef.get_nodes_extended(),
+                                 roles='webserver,dbserver')
         self.assertEqual(len(data), 6)
         self.assertEqual(data[1]['name'], "testnode3.mydomain.com")
 
@@ -123,13 +127,16 @@ class TestData(TestCase):
         """Should filter nodes acording to their virt value"""
         total_guests = 7
         total_hosts = 1
-        data = chef.filter_nodes(chef.get_nodes_extended(), virt_roles='guest')
+        data = chef.filter_nodes(chef.get_nodes_extended(),
+                                 virt_roles='guest')
         self.assertEqual(len(data), total_guests)
 
-        data = chef.filter_nodes(chef.get_nodes_extended(), virt_roles='host')
+        data = chef.filter_nodes(chef.get_nodes_extended(),
+                                 virt_roles='host')
         self.assertEqual(len(data), total_hosts)
 
-        data = chef.filter_nodes(chef.get_nodes_extended(), virt_roles='host,guest')
+        data = chef.filter_nodes(chef.get_nodes_extended(),
+                                 virt_roles='host,guest')
         self.assertEqual(len(data), TOTAL_NODES)
 
     def test_filter_nodes_combined(self):
@@ -143,8 +150,8 @@ class TestData(TestCase):
         self.assertEqual(data[1]['name'], "testnode2")
         self.assertEqual(data[2]['name'], "testnode7")
 
-        data = chef.filter_nodes(chef.get_nodes_extended(), env='staging', roles='webserver',
-                                 virt_roles='guest')
+        data = chef.filter_nodes(chef.get_nodes_extended(), env='staging',
+                                 roles='webserver', virt_roles='guest')
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['name'], "testnode4")
 
@@ -297,8 +304,10 @@ class TestGraph(TestCase):
         error_msg = "Unable to draw graph, timeout exceeded"
         data = chef.filter_nodes(self.nodes, 'production')
 
-        with patch('kitchen.dashboard.graphs.GraphThread.isAlive', return_value=True):
-            with patch('kitchen.dashboard.graphs.GraphThread.kill', return_value=True):
+        with patch('kitchen.dashboard.graphs.GraphThread.isAlive',
+                   return_value=True):
+            with patch('kitchen.dashboard.graphs.GraphThread.kill',
+                       return_value=True):
                 success, msg = graphs.generate_node_map(data, self.roles)
         self.assertFalse(success)
         self.assertTrue(error_msg in msg)
@@ -416,7 +425,8 @@ class TestViews(TestCase):
             def mock_method(a, b, c):
                 return False, error_msg
             return mock_method
-        with patch.object(graphs, 'generate_node_map', new_callable=mock_factory):
+        with patch.object(graphs, 'generate_node_map',
+                          new_callable=mock_factory):
             resp = self.client.get("/graph/")
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(error_msg in resp.content,

--- a/kitchen/dashboard/tests.py
+++ b/kitchen/dashboard/tests.py
@@ -1,14 +1,13 @@
 """Tests for the kitchen.dashboard app"""
 import os
 import simplejson as json
-from copy import deepcopy
 
 from django.test import TestCase
 from mock import patch
 
 from kitchen.dashboard import chef, graphs
 from kitchen.dashboard.templatetags import filters
-from kitchen.settings import STATIC_ROOT, REPO
+from kitchen.settings import MEDIA_ROOT, STATIC_ROOT, REPO
 
 # We need to always regenerate the node data bag in case there where changes
 chef.build_node_data_bag()
@@ -180,7 +179,7 @@ class TestData(TestCase):
 class TestGraph(TestCase):
     nodes = chef.get_nodes_extended()
     roles = chef.get_roles()
-    filepath = os.path.join(STATIC_ROOT, 'img', 'node_map.svg')
+    filepath = os.path.join(MEDIA_ROOT, 'node_map.svg')
 
     def setUp(self):
         if os.path.exists(self.filepath):

--- a/kitchen/settings.py
+++ b/kitchen/settings.py
@@ -46,8 +46,8 @@ DATABASES = {
     }
 }
 
-MEDIA_ROOT = ''
-MEDIA_URL = ''
+MEDIA_ROOT = os.path.join(BASE_PATH, 'dashboard', 'media')
+MEDIA_URL = '/media/'
 STATIC_ROOT = os.path.join(BASE_PATH, 'dashboard', 'static')
 STATIC_URL = '/static/'
 

--- a/kitchen/templates/graph.html
+++ b/kitchen/templates/graph.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block bodycontent %}
-{% if draw_graph %}<img src="/static/img/node_map.svg">{% endif %}
+{% if draw_graph %}<img src="/media/node_map.svg">{% endif %}
 {% endblock %}
 
 {% block bodytail %}

--- a/kitchen/urls.py
+++ b/kitchen/urls.py
@@ -17,3 +17,4 @@ urlpatterns = patterns('',
 )
 
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Serving the graph images in `/media/` instead of in `/static/img` seems a good idea, because the second is for files that are not going to change (and the graphs are changing with each chef repository commit). Although they are not uploaded by the user, I think that `/media/`is a better fit.

This branch does that.
